### PR TITLE
Restore KITTI driver code, modernized for cv4

### DIFF
--- a/config/kitti_odom/cam03.yaml
+++ b/config/kitti_odom/cam03.yaml
@@ -2,8 +2,8 @@
 ---
 model_type: PINHOLE
 camera_name: camera
-image_width: 1241
-image_height: 376
+image_width: 1242
+image_height: 375
 distortion_parameters:
    k1: 0
    k2: 0

--- a/config/kitti_odom/cam04-12.yaml
+++ b/config/kitti_odom/cam04-12.yaml
@@ -2,8 +2,8 @@
 ---
 model_type: PINHOLE
 camera_name: camera
-image_width: 1241
-image_height: 376
+image_width: 1226
+image_height: 370
 distortion_parameters:
    k1: 0
    k2: 0

--- a/config/kitti_odom/kitti_config03.yaml
+++ b/config/kitti_odom/kitti_config03.yaml
@@ -11,8 +11,8 @@ output_path: "/home/tony-ws1/output/"
 
 cam0_calib: "cam03.yaml"
 cam1_calib: "cam03.yaml"
-image_width: 1241
-image_height: 376
+image_width: 1242
+image_height: 375
    
 
 # Extrinsic parameter between IMU and Camera.

--- a/config/kitti_odom/kitti_config04-12.yaml
+++ b/config/kitti_odom/kitti_config04-12.yaml
@@ -11,8 +11,8 @@ output_path: "/home/tony-ws1/output/"
 
 cam0_calib: "cam04-12.yaml"
 cam1_calib: "cam04-12.yaml"
-image_width: 1241
-image_height: 376
+image_width: 1226
+image_height: 370
    
 # Extrinsic parameter between IMU and Camera.
 estimate_extrinsic: 0   # 0  Have an accurate extrinsic parameters. We will trust the following imu^R_cam, imu^T_cam, don't change it.

--- a/loop_fusion/src/pose_graph.cpp
+++ b/loop_fusion/src/pose_graph.cpp
@@ -184,16 +184,16 @@ void PoseGraph::addKeyFrame(KeyFrame* cur_kf, bool flag_detect_loop)
         ofstream loop_path_file(VINS_RESULT_PATH, ios::app);
         loop_path_file.setf(ios::fixed, ios::floatfield);
         loop_path_file.precision(0);
-        loop_path_file << cur_kf->time_stamp * 1e9 << ",";
+        loop_path_file << cur_kf->time_stamp * 1e9 << " ";
         loop_path_file.precision(5);
-        loop_path_file  << P.x() << ","
-              << P.y() << ","
-              << P.z() << ","
-              << Q.w() << ","
-              << Q.x() << ","
-              << Q.y() << ","
-              << Q.z() << ","
-              << endl;
+        loop_path_file  << P.x() << " "
+                        << P.y() << " "
+                        << P.z() << " "
+                        << Q.x() << " "
+                        << Q.y() << " "
+                        << Q.z() << " "
+                        << Q.w() << " "
+                        << endl;
         loop_path_file.close();
     }
     //draw local connection

--- a/loop_fusion/src/pose_graph.cpp
+++ b/loop_fusion/src/pose_graph.cpp
@@ -183,17 +183,15 @@ void PoseGraph::addKeyFrame(KeyFrame* cur_kf, bool flag_detect_loop)
     {
         ofstream loop_path_file(VINS_RESULT_PATH, ios::app);
         loop_path_file.setf(ios::fixed, ios::floatfield);
-        loop_path_file.precision(0);
-        loop_path_file << cur_kf->time_stamp * 1e9 << " ";
-        loop_path_file.precision(5);
+        loop_path_file.precision(9);
+        loop_path_file << cur_kf->time_stamp << " ";
         loop_path_file  << P.x() << " "
                         << P.y() << " "
                         << P.z() << " "
                         << Q.x() << " "
                         << Q.y() << " "
                         << Q.z() << " "
-                        << Q.w() << " "
-                        << endl;
+                        << Q.w() << endl;
         loop_path_file.close();
     }
     //draw local connection
@@ -832,17 +830,15 @@ void PoseGraph::updatePath()
         {
             ofstream loop_path_file(VINS_RESULT_PATH, ios::app);
             loop_path_file.setf(ios::fixed, ios::floatfield);
-            loop_path_file.precision(0);
-            loop_path_file << (*it)->time_stamp * 1e9 << " ";
-            loop_path_file.precision(5);
+            loop_path_file.precision(9);
+            loop_path_file << (*it)->time_stamp << " ";
             loop_path_file  << P.x() << " "
                             << P.y() << " "
                             << P.z() << " "
                             << Q.x() << " "
                             << Q.y() << " "
                             << Q.z() << " "
-                            << Q.w() << " "
-                            << endl;
+                            << Q.w() << endl;
             loop_path_file.close();
         }
         //draw local connection

--- a/loop_fusion/src/pose_graph.cpp
+++ b/loop_fusion/src/pose_graph.cpp
@@ -601,6 +601,8 @@ void PoseGraph::optimize4DoF()
                 (*it)->updatePose(P, R);
             }
             m_keyframelist.unlock();
+
+            ROS_WARN("Successfully optimize pose graph");
             updatePath();
         }
 
@@ -833,14 +835,14 @@ void PoseGraph::updatePath()
             loop_path_file.precision(0);
             loop_path_file << (*it)->time_stamp * 1e9 << ",";
             loop_path_file.precision(5);
-            loop_path_file  << P.x() << ","
-                  << P.y() << ","
-                  << P.z() << ","
-                  << Q.w() << ","
-                  << Q.x() << ","
-                  << Q.y() << ","
-                  << Q.z() << ","
-                  << endl;
+            loop_path_file  << P.x() << " "
+                            << P.y() << " "
+                            << P.z() << " "
+                            << Q.x() << " "
+                            << Q.y() << " "
+                            << Q.z() << " "
+                            << Q.w() << " "
+                            << endl;
             loop_path_file.close();
         }
         //draw local connection

--- a/loop_fusion/src/pose_graph.cpp
+++ b/loop_fusion/src/pose_graph.cpp
@@ -833,7 +833,7 @@ void PoseGraph::updatePath()
             ofstream loop_path_file(VINS_RESULT_PATH, ios::app);
             loop_path_file.setf(ios::fixed, ios::floatfield);
             loop_path_file.precision(0);
-            loop_path_file << (*it)->time_stamp * 1e9 << ",";
+            loop_path_file << (*it)->time_stamp * 1e9 << " ";
             loop_path_file.precision(5);
             loop_path_file  << P.x() << " "
                             << P.y() << " "

--- a/loop_fusion/src/pose_graph_node.cpp
+++ b/loop_fusion/src/pose_graph_node.cpp
@@ -502,7 +502,7 @@ int main(int argc, char **argv)
     }
 
     // Save pose graph
-    posegraph.savePoseGraph();
+    // posegraph.savePoseGraph();
 
     return 0;
 }

--- a/loop_fusion/src/pose_graph_node.cpp
+++ b/loop_fusion/src/pose_graph_node.cpp
@@ -497,7 +497,12 @@ int main(int argc, char **argv)
     measurement_process = std::thread(process);
     keyboard_command_process = std::thread(command);
     
-    ros::spin();
+    while (ros::ok()) {
+        ros::spin();
+    }
+
+    // Save pose graph
+    posegraph.savePoseGraph();
 
     return 0;
 }

--- a/vins_estimator/CMakeLists.txt
+++ b/vins_estimator/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -g")
 
 find_package(catkin REQUIRED COMPONENTS
     roscpp
+    rosbag
     std_msgs
     geometry_msgs
     nav_msgs
@@ -54,10 +55,13 @@ target_link_libraries(vins_lib ${catkin_LIBRARIES} ${OpenCV_LIBS} ${CERES_LIBRAR
 
 
 add_executable(vins_node src/rosNodeTest.cpp)
-target_link_libraries(vins_node vins_lib) 
+target_link_libraries(vins_node vins_lib)
+
+add_executable(vins_from_rosbag src/serialFromRosbag.cpp)
+target_link_libraries(vins_from_rosbag vins_lib)
 
 add_executable(kitti_odom_test src/KITTIOdomTest.cpp)
-target_link_libraries(kitti_odom_test vins_lib) 
+target_link_libraries(kitti_odom_test vins_lib)
 
 add_executable(kitti_gps_test src/KITTIGPSTest.cpp)
-target_link_libraries(kitti_gps_test vins_lib) 
+target_link_libraries(kitti_gps_test vins_lib)

--- a/vins_estimator/CMakeLists.txt
+++ b/vins_estimator/CMakeLists.txt
@@ -55,3 +55,9 @@ target_link_libraries(vins_lib ${catkin_LIBRARIES} ${OpenCV_LIBS} ${CERES_LIBRAR
 
 add_executable(vins_node src/rosNodeTest.cpp)
 target_link_libraries(vins_node vins_lib) 
+
+add_executable(kitti_odom_test src/KITTIOdomTest.cpp)
+target_link_libraries(kitti_odom_test vins_lib) 
+
+add_executable(kitti_gps_test src/KITTIGPSTest.cpp)
+target_link_libraries(kitti_gps_test vins_lib) 

--- a/vins_estimator/package.xml
+++ b/vins_estimator/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.0</version>
   <description>The vins package</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="qintonguav@gmail.com">qintong</maintainer>
@@ -41,6 +41,7 @@
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
+  <build_depend>rosbag</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>camera_models</build_depend>
 

--- a/vins_estimator/src/KITTIGPSTest.cpp
+++ b/vins_estimator/src/KITTIGPSTest.cpp
@@ -1,0 +1,190 @@
+/*******************************************************
+ * Copyright (C) 2019, Aerial Robotics Group, Hong Kong University of Science and Technology
+ * 
+ * This file is part of VINS.
+ * 
+ * Licensed under the GNU General Public License v3.0;
+ * you may not use this file except in compliance with the License.
+ *
+ * Author: Qin Tong (qintonguav@gmail.com)
+ *******************************************************/
+
+#include <iostream>
+#include <stdio.h>
+#include <cmath>
+#include <string>
+#include <opencv2/opencv.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <ros/ros.h>
+#include <sensor_msgs/NavSatFix.h>
+#include "estimator/estimator.h"
+#include "utility/visualization.h"
+
+using namespace std;
+using namespace Eigen;
+
+Estimator estimator;
+ros::Publisher pubGPS;
+
+int main(int argc, char** argv)
+{
+	ros::init(argc, argv, "vins_estimator");
+	ros::NodeHandle n("~");
+	ros::console::set_logger_level(ROSCONSOLE_DEFAULT_NAME, ros::console::levels::Info);
+
+	pubGPS = n.advertise<sensor_msgs::NavSatFix>("/gps", 1000);
+
+	if(argc != 3)
+	{
+		printf("please intput: rosrun vins kitti_gps_test [config file] [data folder] \n"
+			   "for example: rosrun vins kitti_gps_test "
+			   "~/catkin_ws/src/VINS-Fusion/config/kitti_raw/kitti_10_03_config.yaml "
+			   "/media/tony-ws1/disk_D/kitti/2011_10_03/2011_10_03_drive_0027_sync/ \n");
+		return 1;
+	}
+
+	string config_file = argv[1];
+	printf("config_file: %s\n", argv[1]);
+	string sequence = argv[2];
+	printf("read sequence: %s\n", argv[2]);
+	string dataPath = sequence + "/";
+
+	// load image list
+	FILE* file;
+	file = std::fopen((dataPath + "image_00/timestamps.txt").c_str() , "r");
+	if(file == NULL){
+	    printf("cannot find file: %simage_00/timestamps.txt \n", dataPath.c_str());
+	    ROS_BREAK();
+	    return 0;          
+	}
+	vector<double> imageTimeList;
+	int year, month, day;
+	int hour, minute;
+	double second;
+	while (fscanf(file, "%d-%d-%d %d:%d:%lf", &year, &month, &day, &hour, &minute, &second) != EOF)
+	{
+		//printf("%lf\n", second);
+	    imageTimeList.push_back(hour * 60 * 60 + minute * 60 + second);
+	}
+	std::fclose(file);
+
+	// load gps list
+	vector<double> GPSTimeList;
+	{
+		FILE* file;
+		file = std::fopen((dataPath + "oxts/timestamps.txt").c_str() , "r");
+		if(file == NULL){
+		    printf("cannot find file: %soxts/timestamps.txt \n", dataPath.c_str());
+		    ROS_BREAK();
+		    return 0;          
+		}
+		int year, month, day;
+		int hour, minute;
+		double second;
+		while (fscanf(file, "%d-%d-%d %d:%d:%lf", &year, &month, &day, &hour, &minute, &second) != EOF)
+		{
+			//printf("%lf\n", second);
+		    GPSTimeList.push_back(hour * 60 * 60 + minute * 60 + second);
+		}
+		std::fclose(file);
+	}
+
+	readParameters(config_file);
+	estimator.setParameter();
+	registerPub(n);
+
+	FILE* outFile;
+	outFile = fopen((OUTPUT_FOLDER + "/vio.txt").c_str(),"w");
+	if(outFile == NULL)
+		printf("Output path dosen't exist: %s\n", OUTPUT_FOLDER.c_str());
+	string leftImagePath, rightImagePath;
+	cv::Mat imLeft, imRight;
+	double baseTime;
+
+	for (size_t i = 0; i < imageTimeList.size(); i++)
+	{	
+		if(ros::ok())
+		{
+			if(imageTimeList[0] < GPSTimeList[0])
+				baseTime = imageTimeList[0];
+			else
+				baseTime = GPSTimeList[0];
+			
+			//printf("base time is %f\n", baseTime);
+			printf("process image %d\n", (int)i);
+			stringstream ss;
+			ss << setfill('0') << setw(10) << i;
+			leftImagePath = dataPath + "image_00/data/" + ss.str() + ".png";
+			rightImagePath = dataPath + "image_01/data/" + ss.str() + ".png";
+			printf("%s\n", leftImagePath.c_str() );
+			printf("%s\n", rightImagePath.c_str() );
+
+			imLeft = cv::imread(leftImagePath, cv::IMREAD_GRAYSCALE );
+			imRight = cv::imread(rightImagePath, cv::IMREAD_GRAYSCALE );
+
+			double imgTime = imageTimeList[i] - baseTime;
+
+			// load gps
+			FILE* GPSFile;
+			string GPSFilePath = dataPath + "oxts/data/" + ss.str() + ".txt";
+			GPSFile = std::fopen(GPSFilePath.c_str() , "r");
+			if(GPSFile == NULL){
+			    printf("cannot find file: %s\n", GPSFilePath.c_str());
+			    ROS_BREAK();
+			    return 0;          
+			}
+			double lat, lon, alt, roll, pitch, yaw;
+			double vn, ve, vf, vl, vu;
+			double ax, ay, az, af, al, au;
+			double wx, wy, wz, wf, wl, wu;
+			double pos_accuracy, vel_accuracy;
+			double navstat, numsats;
+			double velmode, orimode;
+			
+			fscanf(GPSFile, "%lf %lf %lf %lf %lf %lf ", &lat, &lon, &alt, &roll, &pitch, &yaw);
+			//printf("lat:%lf lon:%lf alt:%lf roll:%lf pitch:%lf yaw:%lf \n",  lat, lon, alt, roll, pitch, yaw);
+			fscanf(GPSFile, "%lf %lf %lf %lf %lf ", &vn, &ve, &vf, &vl, &vu);
+			//printf("vn:%lf ve:%lf vf:%lf vl:%lf vu:%lf \n",  vn, ve, vf, vl, vu);
+			fscanf(GPSFile, "%lf %lf %lf %lf %lf %lf ", &ax, &ay, &az, &af, &al, &au);
+			//printf("ax:%lf ay:%lf az:%lf af:%lf al:%lf au:%lf\n",  ax, ay, az, af, al, au);
+			fscanf(GPSFile, "%lf %lf %lf %lf %lf %lf ", &wx, &wy, &wz, &wf, &wl, &wu);
+			//printf("wx:%lf wy:%lf wz:%lf wf:%lf wl:%lf wu:%lf\n",  wx, wy, wz, wf, wl, wu);
+			fscanf(GPSFile, "%lf %lf %lf %lf %lf %lf ", &pos_accuracy, &vel_accuracy, &navstat, &numsats, &velmode, &orimode);
+			//printf("pos_accuracy:%lf vel_accuracy:%lf navstat:%lf numsats:%lf velmode:%lf orimode:%lf\n", 
+			//	    pos_accuracy, vel_accuracy, navstat, numsats, velmode, orimode);
+
+			std::fclose(GPSFile);
+
+			sensor_msgs::NavSatFix gps_position;
+			gps_position.header.frame_id = "NED";
+			gps_position.header.stamp = ros::Time(imgTime);
+			gps_position.status.status = navstat;
+			gps_position.status.service = numsats;
+			gps_position.latitude  = lat;
+			gps_position.longitude = lon;
+			gps_position.altitude  = alt;
+			gps_position.position_covariance[0] = pos_accuracy;
+			//printf("pos_accuracy %f \n", pos_accuracy);
+			pubGPS.publish(gps_position);
+
+			estimator.inputImage(imgTime, imLeft, imRight);
+			
+			Eigen::Matrix<double, 4, 4> pose;
+			estimator.getPoseInWorldFrame(pose);
+			if(outFile != NULL)
+				fprintf (outFile, "%f %f %f %f %f %f %f %f %f %f %f %f \n",pose(0,0), pose(0,1), pose(0,2),pose(0,3),
+																	       pose(1,0), pose(1,1), pose(1,2),pose(1,3),
+																	       pose(2,0), pose(2,1), pose(2,2),pose(2,3));
+			
+			// cv::imshow("leftImage", imLeft);
+			// cv::imshow("rightImage", imRight);
+			// cv::waitKey(2);
+		}
+		else
+			break;
+	}
+	if(outFile != NULL)
+		fclose (outFile);
+	return 0;
+}
+

--- a/vins_estimator/src/KITTIOdomTest.cpp
+++ b/vins_estimator/src/KITTIOdomTest.cpp
@@ -1,0 +1,125 @@
+/*******************************************************
+ * Copyright (C) 2019, Aerial Robotics Group, Hong Kong University of Science and Technology
+ * 
+ * This file is part of VINS.
+ * 
+ * Licensed under the GNU General Public License v3.0;
+ * you may not use this file except in compliance with the License.
+ *
+ * Author: Qin Tong (qintonguav@gmail.com)
+ *******************************************************/
+
+#include <iostream>
+#include <stdio.h>
+#include <opencv2/opencv.hpp>
+#include <cmath>
+#include <string>
+#include <ros/ros.h>
+#include <sensor_msgs/Image.h>
+#include <cv_bridge/cv_bridge.h>
+#include "estimator/estimator.h"
+#include "utility/visualization.h"
+
+using namespace std;
+using namespace Eigen;
+
+Estimator estimator;
+
+Eigen::Matrix3d c1Rc0, c0Rc1;
+Eigen::Vector3d c1Tc0, c0Tc1;
+
+int main(int argc, char** argv)
+{
+	ros::init(argc, argv, "vins_estimator");
+	ros::NodeHandle n("~");
+	ros::console::set_logger_level(ROSCONSOLE_DEFAULT_NAME, ros::console::levels::Info);
+
+	ros::Publisher pubLeftImage = n.advertise<sensor_msgs::Image>("/leftImage",1000);
+	ros::Publisher pubRightImage = n.advertise<sensor_msgs::Image>("/rightImage",1000);
+
+	if(argc != 3)
+	{
+		printf("please intput: rosrun vins kitti_odom_test [config file] [data folder] \n"
+			   "for example: rosrun vins kitti_odom_test "
+			   "~/catkin_ws/src/VINS-Fusion/config/kitti_odom/kitti_config00-02.yaml "
+			   "/media/tony-ws1/disk_D/kitti/odometry/sequences/00/ \n");
+		return 1;
+	}
+
+	string config_file = argv[1];
+	printf("config_file: %s\n", argv[1]);
+	string sequence = argv[2];
+	printf("read sequence: %s\n", argv[2]);
+	string dataPath = sequence + "/";
+
+	readParameters(config_file);
+	estimator.setParameter();
+	registerPub(n);
+
+	// load image list
+	FILE* file;
+	file = std::fopen((dataPath + "times.txt").c_str() , "r");
+	if(file == NULL){
+	    printf("cannot find file: %stimes.txt\n", dataPath.c_str());
+	    ROS_BREAK();
+	    return 0;          
+	}
+	double imageTime;
+	vector<double> imageTimeList;
+	while ( fscanf(file, "%lf", &imageTime) != EOF)
+	{
+	    imageTimeList.push_back(imageTime);
+	}
+	std::fclose(file);
+
+	string leftImagePath, rightImagePath;
+	cv::Mat imLeft, imRight;
+	FILE* outFile;
+	outFile = fopen((OUTPUT_FOLDER + "/vio.txt").c_str(),"w");
+	if(outFile == NULL)
+		printf("Output path dosen't exist: %s\n", OUTPUT_FOLDER.c_str());
+
+	for (size_t i = 0; i < imageTimeList.size(); i++)
+	{	
+		if(ros::ok())
+		{
+			printf("\nprocess image %d\n", (int)i);
+			stringstream ss;
+			ss << setfill('0') << setw(6) << i;
+			leftImagePath = dataPath + "image_0/" + ss.str() + ".png";
+			rightImagePath = dataPath + "image_1/" + ss.str() + ".png";
+			//printf("%lu  %f \n", i, imageTimeList[i]);
+			//printf("%s\n", leftImagePath.c_str() );
+			//printf("%s\n", rightImagePath.c_str() );
+
+			imLeft = cv::imread(leftImagePath, cv::IMREAD_GRAYSCALE );
+			sensor_msgs::ImagePtr imLeftMsg = cv_bridge::CvImage(std_msgs::Header(), "mono8", imLeft).toImageMsg();
+			imLeftMsg->header.stamp = ros::Time(imageTimeList[i]);
+			pubLeftImage.publish(imLeftMsg);
+
+			imRight = cv::imread(rightImagePath, cv::IMREAD_GRAYSCALE );
+			sensor_msgs::ImagePtr imRightMsg = cv_bridge::CvImage(std_msgs::Header(), "mono8", imRight).toImageMsg();
+			imRightMsg->header.stamp = ros::Time(imageTimeList[i]);
+			pubRightImage.publish(imRightMsg);
+
+
+			estimator.inputImage(imageTimeList[i], imLeft, imRight);
+			
+			Eigen::Matrix<double, 4, 4> pose;
+			estimator.getPoseInWorldFrame(pose);
+			if(outFile != NULL)
+				fprintf (outFile, "%f %f %f %f %f %f %f %f %f %f %f %f \n",pose(0,0), pose(0,1), pose(0,2),pose(0,3),
+																	       pose(1,0), pose(1,1), pose(1,2),pose(1,3),
+																	       pose(2,0), pose(2,1), pose(2,2),pose(2,3));
+			
+			//cv::imshow("leftImage", imLeft);
+			//cv::imshow("rightImage", imRight);
+			//cv::waitKey(2);
+		}
+		else
+			break;
+	}
+	if(outFile != NULL)
+		fclose (outFile);
+	return 0;
+}

--- a/vins_estimator/src/KITTIOdomTest.cpp
+++ b/vins_estimator/src/KITTIOdomTest.cpp
@@ -1,8 +1,8 @@
 /*******************************************************
  * Copyright (C) 2019, Aerial Robotics Group, Hong Kong University of Science and Technology
- * 
+ *
  * This file is part of VINS.
- * 
+ *
  * Licensed under the GNU General Public License v3.0;
  * you may not use this file except in compliance with the License.
  *
@@ -62,7 +62,7 @@ int main(int argc, char** argv)
 	if(file == NULL){
 	    printf("cannot find file: %stimes.txt\n", dataPath.c_str());
 	    ROS_BREAK();
-	    return 0;          
+	    return 0;
 	}
 	double imageTime;
 	vector<double> imageTimeList;
@@ -80,7 +80,7 @@ int main(int argc, char** argv)
 		printf("Output path dosen't exist: %s\n", OUTPUT_FOLDER.c_str());
 
 	for (size_t i = 0; i < imageTimeList.size(); i++)
-	{	
+	{
 		if(ros::ok())
 		{
 			printf("\nprocess image %d\n", (int)i);
@@ -104,14 +104,14 @@ int main(int argc, char** argv)
 
 
 			estimator.inputImage(imageTimeList[i], imLeft, imRight);
-			
+
 			Eigen::Matrix<double, 4, 4> pose;
 			estimator.getPoseInWorldFrame(pose);
 			if(outFile != NULL)
 				fprintf (outFile, "%f %f %f %f %f %f %f %f %f %f %f %f \n",pose(0,0), pose(0,1), pose(0,2),pose(0,3),
 																	       pose(1,0), pose(1,1), pose(1,2),pose(1,3),
 																	       pose(2,0), pose(2,1), pose(2,2),pose(2,3));
-			
+
 			//cv::imshow("leftImage", imLeft);
 			//cv::imshow("rightImage", imRight);
 			//cv::waitKey(2);
@@ -119,7 +119,13 @@ int main(int argc, char** argv)
 		else
 			break;
 	}
+
 	if(outFile != NULL)
 		fclose (outFile);
+
+    // Log timing and memory usage
+	memUsage::dumpVectorToFile(estimator.vTimesKeyframes, "VINS_KeyframeTrackTiming.txt");
+    memUsage::dumpVectorToFile(estimator.vMemUsageKeyframes, "VINS_KeyframeMemUsageKB.txt");
+
 	return 0;
 }

--- a/vins_estimator/src/estimator/estimator.cpp
+++ b/vins_estimator/src/estimator/estimator.cpp
@@ -191,9 +191,16 @@ void Estimator::inputImage(double t, const cv::Mat &_img, const cv::Mat &_img1)
         mBuf.unlock();
         TicToc processTime;
         processMeasurements();
-        printf("process time: %f\n", processTime.toc());
+        const double tTrack = processTime.toc();
+        printf("process time: %f\n", tTrack);
+
+        // Log memory and timing if we are in a single-threaded mode (else it's hard...)
+        if (marginalization_flag) // this is their verison of is_keyframe
+        {
+            vTimesKeyframes.push_back(tTrack / 1000.0); // convert back to seconds
+            vMemUsageKeyframes.push_back(memUsage::getMemUsageKB());
+        }
     }
-    
 }
 
 void Estimator::inputIMU(double t, const Vector3d &linearAcceleration, const Vector3d &angularVelocity)

--- a/vins_estimator/src/estimator/estimator.cpp
+++ b/vins_estimator/src/estimator/estimator.cpp
@@ -1117,11 +1117,16 @@ void Estimator::optimization()
     ROS_DEBUG("visual measurement count: %d", f_m_cnt);
     //printf("prepare for ceres: %f \n", t_prepare.toc());
 
+    // Change this to get covariance
+    // https://github.com/HKUST-Aerial-Robotics/VINS-Mono/issues/74
+    // https://github.com/HKUST-Aerial-Robotics/VINS-Fusion/issues/186
+    
     ceres::Solver::Options options;
 
-    options.linear_solver_type = ceres::DENSE_SCHUR;
-    //options.num_threads = 2;
-    options.trust_region_strategy_type = ceres::DOGLEG;
+    options.linear_solver_type = ceres::ITERATIVE_SCHUR;
+    options.preconditioner_type = ceres::SCHUR_JACOBI;
+    options.num_threads = 6;
+    // options.trust_region_strategy_type = ceres::DOGLEG;
     options.max_num_iterations = NUM_ITERATIONS;
     //options.use_explicit_schur_complement = true;
     //options.minimizer_progress_to_stdout = true;
@@ -1136,6 +1141,46 @@ void Estimator::optimization()
     //cout << summary.BriefReport() << endl;
     ROS_DEBUG("Iterations : %d", static_cast<int>(summary.iterations.size()));
     //printf("solver costs: %f \n", t_solver.toc());
+
+    // Covariance Estimation!
+    ceres::Covariance::Options cov_options;
+    cov_options.num_threads = 6;
+    ceres::Covariance covariance(cov_options);
+
+    TicToc t_cov;
+    std::vector<std::pair<const double*, const double*>> covariance_blocks;
+    covariance_blocks.emplace_back(para_Pose[WINDOW_SIZE], para_Pose[WINDOW_SIZE]);
+
+    if (covariance_matrix.size() == 0)
+    {
+        covariance_matrix.assign(36, -1);   // initialize to -1
+    }
+
+    double covariance_pose[SIZE_POSE * SIZE_POSE];
+    if(covariance.Compute(covariance_blocks, &problem))
+    {
+        covariance.GetCovarianceBlock(para_Pose[WINDOW_SIZE], para_Pose[WINDOW_SIZE], covariance_pose);
+        for (int i=0; i<36; i++)
+            covariance_matrix[i] = covariance_pose[i];
+    }
+    else
+    {
+        ROS_DEBUG("covariance computation failed");
+        // Don't update the covariance matrix
+    }
+
+    // Print the 6x6 covariance matrix
+    CHECK(covariance_matrix.size() == 36);
+    cout << "Covariance: " << endl;
+    for (int i=0; i<6; i++)
+    {
+        cout << "[";
+        for (int j=0; j<6; j++)
+        {
+            printf("% 015.5f ", covariance_matrix[i*6 + j]);
+        }
+        cout << "]" << endl;
+    }
 
     double2vector();
     //printf("frame_count: %d \n", frame_count);

--- a/vins_estimator/src/estimator/estimator.h
+++ b/vins_estimator/src/estimator/estimator.h
@@ -37,6 +37,7 @@
 #include "../featureTracker/feature_tracker.h"
 
 // Some utility functions
+// From https://stackoverflow.com/questions/63166/how-to-determine-cpu-and-memory-consumption-from-inside-a-process
 namespace memUsage
 {
 

--- a/vins_estimator/src/estimator/estimator.h
+++ b/vins_estimator/src/estimator/estimator.h
@@ -36,6 +36,53 @@
 #include "../factor/projectionOneFrameTwoCamFactor.h"
 #include "../featureTracker/feature_tracker.h"
 
+// Some utility functions
+namespace memUsage
+{
+
+inline int parseLine(char* line) {
+    // This assumes that a digit will be found and the line ends in " Kb".
+    int i = strlen(line);
+    const char* p = line;
+    while (*p <'0' || *p > '9') p++;
+    line[i-3] = '\0';
+    i = atoi(p);
+    return i;
+}
+
+inline int getMemUsageKB() { // Note: this value is in KB!
+    FILE* file = fopen("/proc/self/status", "r");
+    int result = -1;
+    char line[128];
+
+    while (fgets(line, 128, file) != NULL){
+        if (strncmp(line, "VmRSS:", 6) == 0){
+            result = parseLine(line);
+            break;
+        }
+    }
+    fclose(file);
+    return result;
+}
+
+template<typename T>
+void dumpVectorToFile(const std::vector<T>& vec, const std::string& filename) {
+    std::ofstream outFile(filename);  // Open the file for writing
+
+    if (!outFile) {
+        std::cerr << "Error opening file: " << filename << std::endl;
+        return;
+    }
+
+    for (const T& value: vec) {
+        outFile << value << "\n";  // Write each element to the file, followed by a newline
+    }
+
+    outFile.close();  // Close the file
+    std::cout << "Vector dumped to " << filename << std::endl;
+}
+
+};
 
 class Estimator
 {
@@ -174,4 +221,8 @@ class Estimator
 
     bool initFirstPoseFlag;
     bool initThreadFlag;
+
+    // Introspect
+    vector<double> vTimesKeyframes;
+    vector<int> vMemUsageKeyframes;
 };

--- a/vins_estimator/src/estimator/estimator.h
+++ b/vins_estimator/src/estimator/estimator.h
@@ -226,4 +226,7 @@ class Estimator
     // Introspect
     vector<double> vTimesKeyframes;
     vector<int> vMemUsageKeyframes;
+
+    // covariance
+    vector<double> covariance_matrix;
 };

--- a/vins_estimator/src/estimator/estimator.h
+++ b/vins_estimator/src/estimator/estimator.h
@@ -226,7 +226,4 @@ class Estimator
     // Introspect
     vector<double> vTimesKeyframes;
     vector<int> vMemUsageKeyframes;
-
-    // covariance
-    vector<double> covariance_matrix;
 };

--- a/vins_estimator/src/rosNodeTest.cpp
+++ b/vins_estimator/src/rosNodeTest.cpp
@@ -258,7 +258,15 @@ int main(int argc, char **argv)
     ros::Subscriber sub_cam_switch = n.subscribe("/vins_cam_switch", 100, cam_switch_callback);
 
     std::thread sync_thread{sync_process};
-    ros::spin();
+
+    // Before killing, dump values to a file
+    while (ros::ok())
+    {
+        ros::spin();
+    }
+
+    memUsage::dumpVectorToFile(estimator.vTimesKeyframes, "VINS_KeyframeTrackTiming.txt");
+    memUsage::dumpVectorToFile(estimator.vMemUsageKeyframes, "VINS_KeyframeMemUsageKB.txt");
 
     return 0;
 }

--- a/vins_estimator/src/serialFromRosbag.cpp
+++ b/vins_estimator/src/serialFromRosbag.cpp
@@ -292,8 +292,8 @@ int main(int argc, char **argv)
 
     bag.close();
 
-    memUsage::dumpVectorToFile(estimator.vTimesKeyframes, "VINS_KeyframeTrackTiming.txt");
-    memUsage::dumpVectorToFile(estimator.vMemUsageKeyframes, "VINS_KeyframeMemUsageKB.txt");
+    // memUsage::dumpVectorToFile(estimator.vTimesKeyframes, "VINS_KeyframeTrackTiming.txt");
+    // memUsage::dumpVectorToFile(estimator.vMemUsageKeyframes, "VINS_KeyframeMemUsageKB.txt");
 
     return 0;
 }

--- a/vins_estimator/src/serialFromRosbag.cpp
+++ b/vins_estimator/src/serialFromRosbag.cpp
@@ -238,9 +238,9 @@ int main(int argc, char **argv)
     if (STEREO) {
         topics_to_read.push_back(std::string(IMAGE1_TOPIC));
     }
-    rosbag::View view(bag, rosbag::TopicQuery(topics_to_read));
 
-    for (rosbag::MessageInstance const m : rosbag::View(bag)) {
+    rosbag::View view(bag, rosbag::TopicQuery(topics_to_read));
+    for (rosbag::MessageInstance const m : view) {
         ROS_DEBUG("Read topic [%s]", m.getTopic().c_str());
         if (!ros::ok()) {
             break;
@@ -259,6 +259,7 @@ int main(int argc, char **argv)
             img1_callback(img_msg);
         }
         else {
+            ROS_WARN("Ignoring topic %s", m.getTopic().c_str());
             continue;
         }
 

--- a/vins_estimator/src/serialFromRosbag.cpp
+++ b/vins_estimator/src/serialFromRosbag.cpp
@@ -291,5 +291,9 @@ int main(int argc, char **argv)
     }
 
     bag.close();
+
+    memUsage::dumpVectorToFile(estimator.vTimesKeyframes, "VINS_KeyframeTrackTiming.txt");
+    memUsage::dumpVectorToFile(estimator.vMemUsageKeyframes, "VINS_KeyframeMemUsageKB.txt");
+
     return 0;
 }

--- a/vins_estimator/src/serialFromRosbag.cpp
+++ b/vins_estimator/src/serialFromRosbag.cpp
@@ -208,8 +208,13 @@ void cam_switch_callback(const std_msgs::BoolConstPtr &switch_msg)
 
 int main(int argc, char **argv)
 {
-    if (argc != 3) {
+    if (argc < 3) {
         printf("Usage: rosrun vins vins_from_rosbag [full path to config file] [rosbag_path]\n");
+
+        for (int i = 0; i < argc; i++) {
+            printf("argv[%d]: %s\n", i, argv[i]);
+        }
+
         return 1;
     }
 
@@ -231,6 +236,8 @@ int main(int argc, char **argv)
 
     // Setup ROS
     registerPub(n);
+    ros::Publisher pubLeftImage = n.advertise<sensor_msgs::Image>(IMAGE0_TOPIC, 1000);
+    ros::Publisher pubRightImage = n.advertise<sensor_msgs::Image>(IMAGE1_TOPIC, 1000);
 
     // Read topics from rosbag
     std::vector<std::string> topics_to_read;
@@ -258,10 +265,12 @@ int main(int argc, char **argv)
         else if (m.getTopic() == std::string(IMAGE0_TOPIC)) {
             sensor_msgs::ImageConstPtr img_msg = m.instantiate<sensor_msgs::Image>();
             img0_callback(img_msg);
+            pubLeftImage.publish(img_msg);
         }
         else if (m.getTopic() == std::string(IMAGE1_TOPIC)) {
             sensor_msgs::ImageConstPtr img_msg = m.instantiate<sensor_msgs::Image>();
             img1_callback(img_msg);
+            pubRightImage.publish(img_msg);
         }
         else {
             ROS_WARN("Ignoring topic %s", m.getTopic().c_str());

--- a/vins_estimator/src/utility/visualization.cpp
+++ b/vins_estimator/src/utility/visualization.cpp
@@ -143,6 +143,9 @@ void pubOdometry(const Estimator &estimator, const std_msgs::Header &header)
         odometry.twist.twist.linear.x = estimator.Vs[WINDOW_SIZE].x();
         odometry.twist.twist.linear.y = estimator.Vs[WINDOW_SIZE].y();
         odometry.twist.twist.linear.z = estimator.Vs[WINDOW_SIZE].z();
+        // Add covariance
+        for (size_t i=0; i<36; i++)
+            odometry.pose.covariance[i] = estimator.covariance_matrix[i];
         pub_odometry.publish(odometry);
 
         geometry_msgs::PoseStamped pose_stamped;

--- a/vins_estimator/src/utility/visualization.cpp
+++ b/vins_estimator/src/utility/visualization.cpp
@@ -143,9 +143,6 @@ void pubOdometry(const Estimator &estimator, const std_msgs::Header &header)
         odometry.twist.twist.linear.x = estimator.Vs[WINDOW_SIZE].x();
         odometry.twist.twist.linear.y = estimator.Vs[WINDOW_SIZE].y();
         odometry.twist.twist.linear.z = estimator.Vs[WINDOW_SIZE].z();
-        // Add covariance
-        for (size_t i=0; i<36; i++)
-            odometry.pose.covariance[i] = estimator.covariance_matrix[i];
         pub_odometry.publish(odometry);
 
         geometry_msgs::PoseStamped pose_stamped;


### PR DESCRIPTION
I found your fork of VINS-Fusion useful for some benchmarking. However, as I also require to use the driver code to evaluate on KITTI, I added it back here.

This would make the KITTI section of the readme accurate once again.